### PR TITLE
add Regexp target for sliders

### DIFF
--- a/src/volume-control.ts
+++ b/src/volume-control.ts
@@ -139,11 +139,15 @@ export default class GDeejVolumeControl extends GObject.Object {
         slider.streams.add(stream);
       }
 
-      if (slider.target === SliderTarget.REGEX &&
-        slider.customApp &&
-        (new RegExp(slider.customApp).test(name))
-      ) {
-        slider.streams.add(stream);
+      try {
+        if (slider.target === SliderTarget.REGEX &&
+          slider.customApp &&
+          (new RegExp(slider.customApp).test(name))
+        ) {
+          slider.streams.add(stream);
+        }
+      } catch (e) {
+        console.warn("Syntax error in RegExp targets");
       }
     }
 
@@ -240,14 +244,19 @@ export default class GDeejVolumeControl extends GObject.Object {
   private _getStreamsByRegex(regex: string): Set<Gvc.MixerStream> {
     const result: Set<Gvc.MixerStream> = new Set();
 
-    for (const [name, streams] of this._streams.entries()) {
-      if (!(new RegExp(regex).test(name))) continue;
+    try {
+      let built_regex = new RegExp(regex);
 
-      for (const stream of streams) {
-        result.add(stream);
+      for (const [name, streams] of this._streams.entries()) {
+        if (!(built_regex.test(name))) continue;
+
+        for (const stream of streams) {
+          result.add(stream);
+        }
       }
+    } catch (e) {
+      console.warn("Syntax error in RegExp targets");
     }
-
     return result;
   }
 }

--- a/src/volume-control.ts
+++ b/src/volume-control.ts
@@ -138,6 +138,13 @@ export default class GDeejVolumeControl extends GObject.Object {
       ) {
         slider.streams.add(stream);
       }
+
+      if (slider.target === SliderTarget.REGEX &&
+        slider.customApp &&
+        (new RegExp(slider.customApp).test(name))
+      ) {
+        slider.streams.add(stream);
+      }
     }
 
     const steamSlider = this._sliders.find(
@@ -177,7 +184,7 @@ export default class GDeejVolumeControl extends GObject.Object {
       const oldSlider = oldSliders.find(
         (oldSlider) =>
           oldSlider.target === slider.target &&
-          (oldSlider.target !== SliderTarget.CUSTOM_APP ||
+          ((oldSlider.target !== SliderTarget.CUSTOM_APP && oldSlider.target !== SliderTarget.REGEX) ||
             oldSlider.customApp === slider.customApp)
       );
 
@@ -209,6 +216,8 @@ export default class GDeejVolumeControl extends GObject.Object {
         return new Set([this._control.get_default_source()]);
       case SliderTarget.CUSTOM_APP:
         return this._getStreamsByAppName(appName);
+      case SliderTarget.REGEX:
+        return this._getStreamsByRegex(appName);
       default:
         return new Set();
     }
@@ -219,6 +228,20 @@ export default class GDeejVolumeControl extends GObject.Object {
 
     for (const [name, streams] of this._streams.entries()) {
       if (!name.toLowerCase().includes(appName)) continue;
+
+      for (const stream of streams) {
+        result.add(stream);
+      }
+    }
+
+    return result;
+  }
+
+  private _getStreamsByRegex(regex: string): Set<Gvc.MixerStream> {
+    const result: Set<Gvc.MixerStream> = new Set();
+
+    for (const [name, streams] of this._streams.entries()) {
+      if (!(new RegExp(regex).test(name))) continue;
 
       for (const stream of streams) {
         result.add(stream);

--- a/src/widgets/slider-row.ts
+++ b/src/widgets/slider-row.ts
@@ -117,7 +117,8 @@ export class GDeejSliderRow extends Adw.PreferencesRow {
       SYSTEM: _('System'),
       MIC: _('Microphone'),
       STEAM: _('Steam'),
-      CUSTOM_APP: _('Application')
+      CUSTOM_APP: _('Application'),
+      REGEX: _('RegExp')
     };
 
     let targetKey: keyof typeof SliderTarget;
@@ -239,7 +240,7 @@ export class GDeejSliderRow extends Adw.PreferencesRow {
   }
 
   private _updateView() {
-    if (this._dropdownTarget.get_selected() === SliderTarget.CUSTOM_APP) {
+    if (this._dropdownTarget.get_selected() === SliderTarget.CUSTOM_APP || this._dropdownTarget.get_selected() === SliderTarget.REGEX) {
       this._entryCustomApp.get_parent()!.get_parent()!.visible = true;
     } else {
       this._entryCustomApp.get_parent()!.get_parent()!.visible = false;

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -2,7 +2,8 @@ export enum SliderTarget {
   SYSTEM = 0,
   MIC = 1,
   STEAM = 2,
-  CUSTOM_APP = 3
+  CUSTOM_APP = 3,
+  REGEX = 4
 }
 
 export type SliderSettings = {


### PR DESCRIPTION
Uses JavaScript RegExp objects to filter streams.
Can be useful when more precise control over dynamically changing target names is desirable.
